### PR TITLE
compile views on demand

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,19 +17,19 @@
   },
   "homepage": "https://github.com/complate/complate-fractal",
   "dependencies": {
-    "@frctl/fractal": "^1.1.5",
-    "@std/esm": "^0.9.2",
+    "@frctl/fractal": "^1.1.7",
+    "@std/esm": "^0.11.3",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
-    "complate-stream": "^0.12.4",
+    "complate-stream": "^0.13.0",
     "html": "^1.0.0"
   },
   "devDependencies": {
-    "eslint": "^4.6.1",
+    "eslint": "^4.8.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-node": "^5.1.1",
+    "eslint-plugin-node": "^5.2.0",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
     "purdy": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -18,18 +18,20 @@
   "homepage": "https://github.com/complate/complate-fractal",
   "dependencies": {
     "@frctl/fractal": "^1.1.5",
-    "babel-core": "^6.25.0",
-    "complate-stream": "^0.10.0",
-    "faucet-pipeline-jsx": "^0.10.0",
+    "@std/esm": "^0.9.2",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-register": "^6.26.0",
+    "complate-stream": "^0.12.4",
     "html": "^1.0.0"
   },
   "devDependencies": {
-    "eslint": "^4.4.1",
+    "eslint": "^4.6.1",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
-    "purdy": "^2.2.1"
+    "purdy": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/complate/complate-fractal",
   "dependencies": {
     "@frctl/fractal": "^1.1.7",
-    "@std/esm": "^0.11.3",
+    "@std/esm": "0.11.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
 const babel = require('babel-core')
-const fractal = require('@frctl/fractal')
-const Adapter = fractal.Adapter
-const utils = fractal.utils
+const { Adapter, utils } = require('@frctl/fractal')
 const PseudoStream = require('./pseudo-stream')
 const html = require('html')
 
@@ -26,7 +24,7 @@ class ComplateAdapter extends Adapter {
   compile (input, context, { _self, target, env }) {
     return new Promise((resolve, reject) => {
       const _config = this._app._config // eslint-disable-line no-unused-vars
-      const path = this.path(env).bind(this) // eslint-disable-line no-unused-vars
+      const path = this.pathGenerator(env) // eslint-disable-line no-unused-vars
       const createElement = require(this._config.bundlePath) // eslint-disable-line no-unused-vars
 
       const { code } = babel.transform(input, babelConfig)
@@ -43,17 +41,15 @@ class ComplateAdapter extends Adapter {
     })
   }
 
-  path (env) {
-    return function (pathStr) {
-      const request = env.request
-
+  pathGenerator (env) {
+    return pathStr => {
       if (!env || env.server) {
         return pathStr
-      } else if (request && request.path) {
-        return utils.relUrlPath(pathStr, request.path, this._app.web.get('builder.urls'))
-      } else {
-        return utils.relUrlPath(pathStr, '/', this._app.web.get('builder.urls'))
       }
+
+      const { request } = env
+      const uri = request && request.path || '/'
+      return utils.relUrlPath(pathStr, uri, this._app.web.get('builder.urls'))
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,11 +28,14 @@ class ComplateAdapter extends Adapter {
       const _config = this._app._config // eslint-disable-line no-unused-vars
       const path = this.path(env).bind(this) // eslint-disable-line no-unused-vars
       const createElement = require(this._config.bundlePath) // eslint-disable-line no-unused-vars
-      let js = babel.transform(input, babelConfig).code
-      const fn = eval(js) // eslint-disable-line no-eval
-      const s = new PseudoStream(target && '<!DOCTYPE html>')
-      fn(s, true, () => {
-        resolve(html.prettyPrint(s.read()).replace('###yield###', context.yield))
+
+      const { code } = babel.transform(input, babelConfig)
+      const render = eval(code) // eslint-disable-line no-eval
+
+      const stream = new PseudoStream(target && '<!DOCTYPE html>')
+
+      render(stream, true, () => {
+        resolve(html.prettyPrint(stream.read()).replace('###yield###', context.yield))
       })
     })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,10 @@ class ComplateAdapter extends Adapter {
       const { code } = babel.transform(input, babelConfig)
       const render = eval(code) // eslint-disable-line no-eval
 
-      const stream = new PseudoStream(target && '<!DOCTYPE html>')
+      const stream = new PseudoStream()
+      if (target) { // indicates that we're rendering a document rather than a fragment
+        stream.writeln('<!DOCTYPE html>')
+      }
 
       render(stream, true, () => {
         resolve(html.prettyPrint(stream.read()).replace('###yield###', context.yield))

--- a/src/index.js
+++ b/src/index.js
@@ -1,42 +1,45 @@
-const babel = require('babel-core')
-const { Adapter, utils } = require('@frctl/fractal')
 const PseudoStream = require('./pseudo-stream')
-const html = require('html')
-
-const babelConfig = {
-  plugins: [
-    ['transform-react-jsx', { pragma: 'createElement' }]
-  ]
-}
+const generateView = require('./transpiler')
+const { Adapter, utils } = require('@frctl/fractal')
+const { prettyPrint } = require('html')
 
 class ComplateAdapter extends Adapter {
-  constructor (source, app, config = {}) {
+  constructor (source, app, config) {
     super(null, source)
     this._app = app
-    this._config = config
-    // this._handlePrefix = '$'
+    this._rootDir = config.rootDir
+    this._envPath = config.envPath
+    this._previewPath = config.previewPath
+    this._appContext = config.appContext
   }
 
-  render (path, str, context, meta) {
-    return Promise.resolve(this.compile(str, context, meta))
-  }
+  render (filepath, str, context, meta) {
+    const componentsDir = this._app._config.components.path
 
-  compile (input, context, { _self, target, env }) {
-    return new Promise((resolve, reject) => {
-      const _config = this._app._config // eslint-disable-line no-unused-vars
-      const path = this.pathGenerator(env) // eslint-disable-line no-unused-vars
-      const createElement = require(this._config.bundlePath) // eslint-disable-line no-unused-vars
+    // populate components' application context (NB: not to be confused with Fractal's own `context`)
+    const env = require(this._envPath)
+    const assetPath = this.pathGenerator(meta.env)
+    env.context.uri = (...args) => {
+      // inject `assetPath` via invocation context
+      const ctx = { assetPath }
+      return this._appContext.uri.call(ctx, ...args)
+    }
+    // expose application context via Fractal's own context
+    context.app = env.context
 
-      const { code } = babel.transform(input, babelConfig)
-      const render = eval(code) // eslint-disable-line no-eval
+    const preview = meta.env.request.route.handle === 'preview' // XXX: brittle?
+    const render = generateView(str, {
+      previewPath: preview && this._previewPath,
+      rootDir: this._rootDir,
+      componentsDir
+    })
 
-      const stream = new PseudoStream()
-      if (target) { // indicates that we're rendering a document rather than a fragment
-        stream.writeln('<!DOCTYPE html>')
-      }
-
-      render(stream, true, () => {
-        resolve(html.prettyPrint(stream.read()).replace('###yield###', context.yield))
+    const stream = new PseudoStream()
+    return new Promise(resolve => {
+      render(stream, context, () => {
+        let html = stream.read()
+        html = prettyPrint(html)
+        resolve(html)
       })
     })
   }
@@ -44,11 +47,11 @@ class ComplateAdapter extends Adapter {
   pathGenerator (env) {
     return pathStr => {
       if (!env || env.server) {
-        return pathStr
+        return `/${pathStr}`
       }
 
       const { request } = env
-      const uri = request && request.path || '/'
+      const uri = (request && request.path) || '/'
       return utils.relUrlPath(pathStr, uri, this._app.web.get('builder.urls'))
     }
   }

--- a/src/pseudo-stream.js
+++ b/src/pseudo-stream.js
@@ -1,9 +1,6 @@
 class PseudoStream {
-  constructor (doctype) {
+  constructor () {
     this._buffer = []
-    if (doctype) {
-      this._buffer.push(doctype)
-    }
   }
 
   read () {

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -35,7 +35,7 @@ module.exports = (jsx, { previewPath, rootDir, componentsDir }) => {
     split: false
   })
 
-  imports.push("import renderer, { createElement } from 'complate-stream'")
+  imports.push("import Renderer, { createElement } from 'complate-stream'")
   if (previewPath) {
     imports.push(`import PreviewLayout from '${previewPath}'`)
   }
@@ -47,11 +47,11 @@ module.exports = (jsx, { previewPath, rootDir, componentsDir }) => {
   code = `const generateMacro = context => { return () => ${code} }`
   // generate render function -- XXX: hard-coded doctype
   code = `${code}
-const { renderView } = renderer('<!DOCTYPE html>')
+const renderer = new Renderer('<!DOCTYPE html>')
 const fragment = ${!previewPath}
 export default (stream, context, callback) => {
   const wrapperMacro = generateMacro(context)
-  renderView(wrapperMacro, {}, stream, fragment, callback)
+  renderer.renderView(wrapperMacro, {}, stream, { fragment }, callback)
 }`
   code = imports.concat(code).join('\n')
 

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -1,0 +1,72 @@
+const fs = require('fs')
+const path = require('path')
+
+// activate JSX support -- NB: this must be done before @std/esm
+require('babel-register')({
+  extensions: ['.jsx'],
+  presets: ['es2015'],
+  plugins: [
+    ['transform-react-jsx', { pragma: 'createElement' }]
+  ]
+})
+// activate support for ES6 import/export (required for complate-stream; `require`ing it here
+// makes it work within the generated JSX module below, probably due to Node's module caching)
+require = require('@std/esm')(module, { esm: 'all', cjs: true }) // eslint-disable-line no-global-assign
+require('complate-stream')
+
+module.exports = (jsx, { previewPath, rootDir, componentsDir }) => {
+  // separate imports from markup snippet -- XXX: brittle, but good enough?
+  const { imports, xml } = jsx.split(/\r\n|\r|\n/).reduce((memo, line) => {
+    line = line.trim()
+    if (!line) { // ignore blank lines
+      return memo
+    }
+
+    if (memo.split || !/^import\b/.test(line)) {
+      memo.split = true
+      memo.xml.push(line)
+    } else {
+      memo.imports.push(line)
+    }
+    return memo
+  }, {
+    imports: [],
+    xml: [],
+    split: false
+  })
+
+  imports.push("import renderer, { createElement } from 'complate-stream'")
+  if (previewPath) {
+    imports.push(`import PreviewLayout from '${previewPath}'`)
+  }
+  // generate macro -- XXX: brittle, but good enough?
+  let code = xml.join('\n')
+  if (previewPath) {
+    code = `<PreviewLayout context={context}>${code}</PreviewLayout>`
+  }
+  code = `const generateMacro = context => { return () => ${code} }`
+  // generate render function -- XXX: hard-coded doctype
+  code = `${code}
+const { renderView } = renderer('<!DOCTYPE html>')
+const fragment = ${!previewPath}
+export default (stream, context, callback) => {
+  const wrapperMacro = generateMacro(context)
+  renderView(wrapperMacro, {}, stream, fragment, callback)
+}`
+  code = imports.concat(code).join('\n')
+
+  const filepath = path.resolve(rootDir, `_view_${randomID()}.jsx`)
+  fs.writeFileSync(filepath, code)
+  try {
+    var render = require(filepath).default // eslint-disable-line no-var
+    delete require.cache[filepath]
+  } finally {
+    fs.unlinkSync(filepath)
+  }
+
+  return render
+}
+
+function randomID () {
+  return Math.random().toString().substr(2) // XXX: crude
+}

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -9,9 +9,10 @@ require('babel-register')({
     ['transform-react-jsx', { pragma: 'createElement' }]
   ]
 })
-// activate support for ES6 import/export (required for complate-stream; `require`ing it here
-// makes it work within the generated JSX module below, probably due to Node's module caching)
+// activate support for ES6 import/export syntax (required for non-JSX ES6 modules, notably complate-stream)
 require = require('@std/esm')(module, { esm: 'all', cjs: true }) // eslint-disable-line no-global-assign
+// `require`ing non-JSX ES6 modules here makes `import`s work within JSX modules, because here we have access to
+// @std/esm's `require` and can thus prepopulate Node's module cache appropriately
 require('complate-stream')
 
 module.exports = (jsx, { previewPath, rootDir, componentsDir }) => {


### PR DESCRIPTION
> Compile views on demand, rendering pre-compiled bundles obsolete
>
> complate-stream has removed the ubiquitous/mandatory macro registry in
> favor of JSX's CamelCase convention, which results in object references:
>
>     <foo-bar /> → createElement("foo-bar")
>     <FooBar />  → createElement(FooBar)
>
> This means we can no longer rely on an intermediate step for translating
> string identifiers to the corresponding macro function - which
> essentially required a complete overhaul of the way Fractal compiles
> complate views.
>
> Views are now generated on the fly by wrapping sample snippets (which
> now must include the respective import statements) in some additional
> JavaScript code and piping it all through babel-register.
>
> There remain a few caveats though; see inline comments.

b608f46cbc94b090eccfa032d7e20e3c6328a0aa