### PR TITLE
Fix accidental escaping due to Windows-/DOS-style path separators

### DIFF
--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -38,9 +38,11 @@ module.exports = (jsx, { previewPath, rootDir, componentsDir }) => {
 
   imports.push("import Renderer, { createElement } from 'complate-stream'")
   if (previewPath) {
-    // replace Windows-/DOS-style path separators to avoid accidental escaping
-    let path = previewPath.replace(/\\/g, '/')
-    imports.push(`import PreviewLayout from '${path}'`)
+    // avoid accidental string escaping due to Windows-style path separators
+    if (path.sep === '\\') {
+      previewPath = previewPath.replace(/\\/g, '/')
+    }
+    imports.push(`import PreviewLayout from '${previewPath}'`)
   }
   // generate macro -- XXX: brittle, but good enough?
   let code = xml.join('\n')

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -38,7 +38,9 @@ module.exports = (jsx, { previewPath, rootDir, componentsDir }) => {
 
   imports.push("import Renderer, { createElement } from 'complate-stream'")
   if (previewPath) {
-    imports.push(`import PreviewLayout from '${previewPath}'`)
+    // replace Windows-/DOS-style path separators to avoid accidental escaping
+    let path = previewPath.replace(/\\/g, '/')
+    imports.push(`import PreviewLayout from '${path}'`)
   }
   // generate macro -- XXX: brittle, but good enough?
   let code = xml.join('\n')


### PR DESCRIPTION
> this feels dissatisfactory, as it only addresses a symptom rather than
> the underlying issue: string-based code generation is inherently brittle

ff30caaf210c20812129fc412c386dc1a09eb976