### PR TITLE
Simplify adaptor API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,36 +2,35 @@ const PseudoStream = require('./pseudo-stream')
 const generateView = require('./transpiler')
 const { Adapter, utils } = require('@frctl/fractal')
 const { prettyPrint } = require('html')
+const path = require('path')
 
 class ComplateAdapter extends Adapter {
   constructor (source, app, config) {
     super(null, source)
     this._app = app
     this._rootDir = config.rootDir
+    this._generateURI = config.generateURI
+    // optional settings (defaults provided via corresponding getters)
     this._envPath = config.envPath
     this._previewPath = config.previewPath
-    this._appContext = config.appContext
   }
 
   render (filepath, str, context, meta) {
-    const componentsDir = this._app._config.components.path
-
     // populate components' application context (NB: not to be confused with Fractal's own `context`)
-    const env = require(this._envPath)
+    const env = require(this.envPath)
     const assetPath = this.pathGenerator(meta.env)
     env.context.uri = (...args) => {
       // inject `assetPath` via invocation context
       const ctx = { assetPath }
-      return this._appContext.uri.call(ctx, ...args)
+      return this._generateURI.call(ctx, ...args)
     }
     // expose application context via Fractal's own context
     context.app = env.context
 
     const preview = meta.env.request.route.handle === 'preview' // XXX: brittle?
     const render = generateView(str, {
-      previewPath: preview && this._previewPath,
       rootDir: this._rootDir,
-      componentsDir
+      previewPath: preview && this.previewPath
     })
 
     const stream = new PseudoStream()
@@ -54,6 +53,28 @@ class ComplateAdapter extends Adapter {
       const uri = (request && request.path) || '/'
       return utils.relUrlPath(pathStr, uri, this._app.web.get('builder.urls'))
     }
+  }
+
+  // NB: this getter ensures that `#componentsDir` access is deferred until
+  //     `#_app._config` is populated, which is not necessarily the case within
+  //     the constructor
+  get envPath () {
+    if (this._envPath === undefined) {
+      this._envPath = path.resolve(this.componentsDir, 'env.js')
+    }
+    return this._envPath
+  }
+
+  // NB: cf. `#envPath`
+  get previewPath () {
+    if (this._previewPath === undefined) {
+      this._previewPath = path.resolve(this.componentsDir, '_preview.jsx')
+    }
+    return this._previewPath
+  }
+
+  get componentsDir () {
+    return this._app._config.components.path
   }
 }
 

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -15,7 +15,7 @@ require = require('@std/esm')(module, { esm: 'all', cjs: true }) // eslint-disab
 // @std/esm's `require` and can thus prepopulate Node's module cache appropriately
 require('complate-stream')
 
-module.exports = (jsx, { previewPath, rootDir, componentsDir }) => {
+module.exports = (jsx, { rootDir, previewPath }) => {
   // separate imports from markup snippet -- XXX: brittle, but good enough?
   const { imports, xml } = jsx.split(/\r\n|\r|\n/).reduce((memo, line) => {
     line = line.trim()


### PR DESCRIPTION
> * replaced `appContext` with `generateURI` to avoid spurious indirections
> * provided defaults for `envPath` and `previewPath`
>
> the latter proved trickier than expected because we can't rely on
> `#_app._config` being populated within the constructor (this might be
> dependent on the order of `fractal.components.engine` and
> `fractal.components.set` invocations within the respective project's
> `fractal.js`, but I'm not entirely sure about that)
>
> as suggested by @mrreynolds

3475c8aea8aca7f26f73594b6d0e8e7cf893236c

we should update the README before releasing v0.4.0