### PR TITLE
Load JSX from node_modules dependencies as well

### DIFF
--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -10,7 +10,8 @@ require('@babel/register')({
       pragma: 'createElement',
       pragmaFrag: 'Fragment'
     }]
-  ]
+  ],
+  ignore: [] // Macros from dependencies might need to be loaded
 })
 // activate support for ES6 import/export syntax (required for non-JSX ES6 modules, notably complate-stream)
 require = require('esm')(module) // eslint-disable-line no-global-assign


### PR DESCRIPTION
This fix modifies the babel config so that `ignore` is turned off and
dependencies can be loaded from the node_modules folder. This is
necessary if you are building a new fractal instance which wants to use
some components from a dependent pattern library.

I'm not sure the effect (if any) that this will have on the performance
of the adapter, but I'm not too worried about it. I would hope 🤞🏻 that
babel is only activated on the fly when the users attempts to load a
dependency, and if that is the case, we should be ok.

Since there is also not really a (good) way to configure which
dependencies that babel would need to load, I think this is the cleanest
option.