### PR TITLE
migrated to fractal-fork and updated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![Build Status](https://travis-ci.org/complate/complate-fractal.svg?branch=master)](https://travis-ci.org/complate/complate-fractal)
 [![Greenkeeper badge](https://badges.greenkeeper.io/complate/complate-fractal.svg)](https://greenkeeper.io/)
 
+**Note:** Because of the security vulnerabilities in the [official fractal branch],
+complate-fractal now uses [this fork](https://github.com/joyheron/fractal).
+
 ## Installation
 
 Add complate-fractal to your Fractal-based styleguide project:
@@ -18,7 +21,7 @@ or
 In your project's `fractal.config.js`, you need to register complate as templating engine:
 
 ```javascript
-let fractal = module.exports = require('@frctl/fractal').create()
+let fractal = module.exports = require('fractal-fork').fractal.create()
 let complate = require('complate-fractal')
 
 …
@@ -123,3 +126,5 @@ Therefore we don’t support Fractal's `@`-prefixed view handlers for now.
 2. Commit as "vX.X.X"
 3. `git tag -am "vX.X.X" "X.X.X"`
 4. `git push --follow-tags`
+
+[official fractal branch]: https://github.com/frctl/fractal

--- a/package.json
+++ b/package.json
@@ -17,21 +17,21 @@
   },
   "homepage": "https://github.com/complate/complate-fractal",
   "dependencies": {
-    "@babel/core": "~7.15.5",
-    "@babel/plugin-transform-react-jsx": "~7.14.9",
-    "@babel/preset-env": "~7.15.6",
-    "@babel/register": "~7.15.3",
-    "@frctl/fractal": "^1.5.11",
-    "complate-stream": "^0.16.9",
+    "@babel/core": "~7.18.9",
+    "@babel/plugin-transform-react-jsx": "~7.18.6",
+    "@babel/preset-env": "~7.18.9",
+    "@babel/register": "~7.18.9",
+    "fractal-fork": "^0.0.3",
+    "complate-stream": "^0.16.10",
     "esm": "^3.2.25",
-    "prettier": "^2.4.1"
+    "prettier": "^2.7.1"
   },
   "devDependencies": {
-    "eslint": "^7.32.0",
-    "eslint-config-standard": "^16.0.3",
-    "eslint-plugin-import": "^2.24.2",
+    "eslint": "^8.20.0",
+    "eslint-config-standard": "^17.0.0",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0",
+    "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^5.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const BufferedStream = require('./buffered-stream')
 const generateView = require('./transpiler')
-const { Adapter, utils } = require('@frctl/fractal')
+const { Adapter, utils } = require('fractal-fork').fractal
 const prettier = require('prettier')
 const path = require('path')
 


### PR DESCRIPTION
Because of the severe vulnerabilities in the official @frctl/fractal
repository, this migrates the Fractal dependency to a fork. The
fractal-fork library is structured a bit differently, but everything
else should work as expected.